### PR TITLE
error handling for invalid urlSegment

### DIFF
--- a/code/Routing/DateLinkController.php
+++ b/code/Routing/DateLinkController.php
@@ -24,6 +24,10 @@ class DateLinkController extends ModelAsController {
 				"URLSegment" => $URLSegment,
 				"ParentID" => $parentID
 			))->first();
+		
+		if( true !== $sitetree instanceof SiteTree ){
+		    ErrorPage::response_for(404);
+        	}
 
 		return self::controller_for($sitetree, $this->request->param('Action'));
 	}

--- a/code/Routing/DateLinkController.php
+++ b/code/Routing/DateLinkController.php
@@ -25,7 +25,7 @@ class DateLinkController extends ModelAsController {
 				"ParentID" => $parentID
 			))->first();
 		
-		if( true !== $sitetree instanceof SiteTree ){
+		if( ! $sitetree instanceof SiteTree ){
 		    return ErrorPage::response_for(404);
         	}
 

--- a/code/Routing/DateLinkController.php
+++ b/code/Routing/DateLinkController.php
@@ -26,7 +26,7 @@ class DateLinkController extends ModelAsController {
 			))->first();
 		
 		if( true !== $sitetree instanceof SiteTree ){
-		    ErrorPage::response_for(404);
+		    return ErrorPage::response_for(404);
         	}
 
 		return self::controller_for($sitetree, $this->request->param('Action'));


### PR DESCRIPTION
Providing an invalid url segment threw an error as controller_for expects an instance of sitetree.
Using ErrorPage::response_for would also enable checking for a changed urlsegment etc.